### PR TITLE
Default to insert mode in the minibuffer

### DIFF
--- a/src/kakit.org
+++ b/src/kakit.org
@@ -29,10 +29,16 @@ This file is the entrypoint to the Kakit package.
 (require 'kakit-modes-insert)
 (require 'kakit-modes-normal)
 
+(defun kakit--get-default-state ()
+  "Return the default state for the current buffer."
+  (if (minibufferp)
+      'insert
+    'normal))
+
 (defun kakit--init-cleanup-helper ()
   "Turn on Kakit mode and clean up on turn off."
   (if kakit-mode
-      (kakit--switch-state-local 'normal)
+      (kakit--switch-state-local (kakit--get-default-state))
     (dolist (state-mode kakit--states)
       (let ((state (car state-mode))
             (mode (cdr state-mode)))
@@ -43,7 +49,7 @@ This file is the entrypoint to the Kakit package.
 ;;;###autoload
 (define-globalized-minor-mode kakit-mode
   kakit-normal-mode
-  (lambda () (kakit--switch-state-local 'normal))
+  (lambda () (kakit--switch-state-local (kakit--get-default-state)))
   :predicate t
   (kakit--init-cleanup-helper))
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Default to insert mode in minibuffer contexts

- Add buffer-aware state initialization logic

- Maintain normal mode for regular buffers


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kakit.org</strong><dd><code>Add context-aware state initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/kakit.org

<li>Added <code>kakit--get-default-state</code> function to determine appropriate <br>initial state<br> <li> Modified initialization to use insert mode for minibuffers, normal <br>mode elsewhere<br> <li> Updated both mode initialization and cleanup helper functions


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Kakit/pull/13/files#diff-b0d3d7d3970ed0d5557fbd0b21a079d40c2d90a5a5a828f412626e37035a5db9">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>