### PR TITLE
Add command to simulate visual mode

### DIFF
--- a/src/commands.org
+++ b/src/commands.org
@@ -165,6 +165,7 @@ arguments are recorded only in the normal state.
 ; -*- lexical-binding: t -*-
 
 (require 'kakit-modes-normal-prefix-arg)
+(require 'kakit-states-state-switching-helper)
 
 (defun kakit-handle-digit-command (digit)
   "Handle digit input in normal mode to build prefix argument.
@@ -175,10 +176,14 @@ DIGIT is the numeric value of the pressed digit (0-9)."
             (+ (* kakit--prefix-argument 10) digit)
           digit)))
 
-(defun kakit-reset-prefix-argument ()
-  "Reset the prefix argument to nil."
+(defun kakit-reset-to-normal-mode ()
+  "Reset the prefix argument to nil, deactivate any active region,
+and switch to normal mode. This function brings the editor back
+to a clean normal mode state."
   (interactive)
-  (setq-local kakit--prefix-argument nil))
+  (setq-local kakit--prefix-argument nil)
+  (deactivate-mark)
+  (kakit--switch-state-local 'normal))
 
 (provide 'kakit-commands-handle-prefix-arg)
 #+end_src

--- a/src/keymaps.org
+++ b/src/keymaps.org
@@ -56,7 +56,7 @@ and reset it to nil after the command is called."
       (define-key keymap (kbd (number-to-string i))
         `(lambda () (interactive) (kakit-handle-digit-command ,i))))
     
-    (define-key keymap (kbd "<escape>") 'kakit-reset-prefix-argument)
+    (define-key keymap (kbd "<escape>") 'kakit-reset-to-normal-mode)
     
     (define-key keymap (kbd "h") (kakit--with-prefix-arg 'backward-char))
     (define-key keymap (kbd "j") (kakit--with-prefix-arg 'next-line))
@@ -69,6 +69,7 @@ and reset it to nil after the command is called."
     (define-key keymap (kbd "d") (kakit--with-prefix-arg 'kakit-kill-region-or-char))
     (define-key keymap (kbd "c") (kakit--with-prefix-arg 'kakit-change))
     
+    (define-key keymap (kbd "v") 'set-mark-command)
     (define-key keymap (kbd "y") 'copy-region-as-kill)
     (define-key keymap (kbd "p") 'yank)
     (define-key keymap (kbd "u") 'undo-only)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add visual mode simulation with 'v' key binding

- Rename and enhance escape key function for better state management

- Improve normal mode reset functionality with region deactivation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commands.org</strong><dd><code>Enhanced normal mode reset with state management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/commands.org

<li>Add new require statement for state switching helper<br> <li> Rename <code>kakit-reset-prefix-argument</code> to <code>kakit-reset-to-normal-mode</code><br> <li> Enhance function to deactivate mark and switch to normal state<br> <li> Update function documentation to reflect expanded functionality


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Kakit/pull/25/files#diff-a1ec8c6d7acb505040f6948cdf636449f4f5a082a21a86488ab5b2584b484a3c">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>keymaps.org</strong><dd><code>Add visual mode key binding and update escape</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/keymaps.org

<li>Update escape key binding to use renamed function<br> <li> Add 'v' key binding to <code>set-mark-command</code> for visual mode simulation


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Kakit/pull/25/files#diff-670ef714f4cc34262d91d7426e97d979346d24b472d3c188a4322c41de7ff405">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>