### PR TITLE
Fix incorrect formatting in README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -78,8 +78,8 @@ $ git clone --branch v1.1.0 --single-branch https://github.com/abhi-kr-2100/Kaki
 $ cd Kakit/ && emacs --batch --load build.el
 #+end_src
 
-After the source files are generated (~1 second), add the
-following to your ~init.el~:
+After the source files are generated (around 1 second), add
+the following to your ~init.el~:
 
 #+begin_src emacs-lisp
 (use-package kakit


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Fix minor formatting inconsistency in README.org


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.org</strong><dd><code>Minor formatting improvement in installation section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.org

<li>Changed "~1 second" to "(around 1 second)" for better readability<br> <li> Adjusted line break positioning in installation instructions


</details>


  </td>
  <td><a href="https://github.com/abhi-kr-2100/Kakit/pull/28/files#diff-ecbc1aa90e9ff97a00b0b2aab1551bceee0c4d21993146bdcb1af4de31c9cac6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>